### PR TITLE
Add alternatives for SI prefix 'micro'

### DIFF
--- a/db.json
+++ b/db.json
@@ -29,6 +29,22 @@
             "scale": "1e-6",
             "name": "micro"
         },
+        "μ": {
+            "scale": "1e-6",
+            "name": "micro"
+        },
+        "µ": {
+            "scale": "1e-6",
+            "name": "micro"
+        },
+        "mu": {
+            "scale": "1e-6",
+            "name": "micro"
+        },
+        "mc": {
+            "scale": "1e-6",
+            "name": "micro"
+        },
         "m": {
             "scale": "1e-3",
             "name": "milli"


### PR DESCRIPTION
This PR adds commonly used alternatives for  SI prefix 'micro'. The unicode characters U+03BC and U+00B5 as well as 'mc' are in common use in chemistry and biomedical field. The prefix code 'mu' is more commonly used in physics